### PR TITLE
feat: add edit mode for all schemas

### DIFF
--- a/studio/components/interfaces/Database/Tables/TableList.tsx
+++ b/studio/components/interfaces/Database/Tables/TableList.tsx
@@ -60,9 +60,9 @@ const TableList: FC<{
     const [filterString, setFilterString] = useState<string>('')
     const tables =
       filterString.length === 0
-        ? meta.tables.list((table: any) => table.schema === 'public')
+        ? meta.tables.list((table: any) => table.schema)
         : meta.tables.list(
-            (table: any) => table.schema === 'public' && table.name.includes(filterString)
+            (table: any) => table.schema && table.name.includes(filterString)
           )
 
     return (

--- a/studio/components/interfaces/TableGridEditor/EmptyState.tsx
+++ b/studio/components/interfaces/TableGridEditor/EmptyState.tsx
@@ -16,7 +16,7 @@ const EmptyState: FC<Props> = ({ selectedSchema, onAddTable }) => {
     return (
       <div className="flex flex-col items-center justify-center space-y-4">
         <p className="text-sm">There are no tables available in this schema</p>
-        {selectedSchema === 'public' && <Button onClick={onAddTable}>Create a new table</Button>}
+        <Button onClick={onAddTable}>Create a new table</Button>
       </div>
     )
   }

--- a/studio/components/interfaces/TableGridEditor/SidePanelEditor/SchemaEditor/SchemaEditor.tsx
+++ b/studio/components/interfaces/TableGridEditor/SidePanelEditor/SchemaEditor/SchemaEditor.tsx
@@ -1,0 +1,91 @@
+import { FC, useEffect, useState } from 'react'
+import { Badge, Checkbox, SidePanel, Input } from '@supabase/ui'
+import { PostgresTable } from '@supabase/postgres-meta'
+import { SchemaField } from './SchemaEditor.types'
+import { useStore } from 'hooks'
+import ActionBar from '../ActionBar'
+
+interface Props {
+  visible: boolean
+  closePanel: () => void
+  saveChanges: (
+    payload: any,
+    resolve: any
+  ) => void
+}
+
+const SchemaEditor: FC<Props> = ({
+  visible = false,
+  closePanel = () => {},
+  saveChanges = () => {},
+}) => {
+  const { ui } = useStore()
+
+  const [errors, setErrors] = useState<any>({})
+  const [schemaFields, setSchemaFields] = useState<SchemaField>()
+
+  useEffect(() => {
+    if (visible) {
+      setErrors({})
+    }
+  }, [visible])
+
+  const onUpdateField = (changes: Partial<SchemaField>) => {
+    const updatedTableFields = { ...schemaFields, ...changes } as SchemaField
+    setSchemaFields(updatedTableFields)
+
+    const updatedErrors = { ...errors }
+    for (const key of Object.keys(changes)) {
+      delete updatedErrors[key]
+    }
+    setErrors(updatedErrors)
+  }
+
+  const onSaveChanges = (resolve: any) => {
+    if (schemaFields && schemaFields.name) {
+      const payload = {
+        name: schemaFields.name
+      };
+
+      saveChanges(payload, resolve)
+    }
+  }
+
+  return (
+    <SidePanel
+      size="large"
+      key="SchemaEditor"
+      visible={visible}
+      // @ts-ignore
+      header="Create a new schema"
+      className="transition-all ease-in duration-100"
+      onCancel={closePanel}
+      onConfirm={() => (resolve: () => void) => onSaveChanges(resolve)}
+      customFooter={
+        <ActionBar
+          backButtonLabel="Cancel"
+          applyButtonLabel="Save"
+          closePanel={closePanel}
+          applyFunction={(resolve: () => void) => onSaveChanges(resolve)}
+        />
+      }
+    >
+      <>
+        <SidePanel.Content>
+          <div className="space-y-10 py-6">
+            <Input
+              label="Name"
+              layout="horizontal"
+              type="text"
+              error={errors.name}
+              value={schemaFields?.name}
+              onChange={(event: any) => onUpdateField({ name: event.target.value })}
+            />
+          </div>
+        </SidePanel.Content>
+      </>
+    </SidePanel>
+  )
+}
+
+export default SchemaEditor

--- a/studio/components/interfaces/TableGridEditor/SidePanelEditor/SchemaEditor/SchemaEditor.types.ts
+++ b/studio/components/interfaces/TableGridEditor/SidePanelEditor/SchemaEditor/SchemaEditor.types.ts
@@ -1,0 +1,5 @@
+export interface SchemaField {
+  id: number
+  name: string
+  owner?: string
+}

--- a/studio/components/interfaces/TableGridEditor/SidePanelEditor/SidePanelEditor.tsx
+++ b/studio/components/interfaces/TableGridEditor/SidePanelEditor/SidePanelEditor.tsx
@@ -10,6 +10,7 @@ import { ColumnField, CreateColumnPayload, UpdateColumnPayload } from './SidePan
 import ConfirmationModal from 'components/ui/ConfirmationModal'
 
 import { Modal } from '@supabase/ui'
+import SchemaEditor from './SchemaEditor/SchemaEditor'
 
 interface Props {
   selectedSchema: string
@@ -17,7 +18,7 @@ interface Props {
   selectedRowToEdit?: Dictionary<any>
   selectedColumnToEdit?: PostgresColumn
   selectedTableToEdit?: PostgresTable
-  sidePanelKey?: 'row' | 'column' | 'table'
+  sidePanelKey?: 'row' | 'column' | 'table' | 'schema'
   isDuplicating?: boolean
   closePanel: () => void
   onRowCreated?: (row: Dictionary<any>) => void
@@ -215,6 +216,27 @@ const SidePanelEditor: FC<Props> = ({
     resolve()
   }
 
+  const saveSchema = async (
+    payload: any,
+    resolve: any
+  ) => {
+    try {
+      const schema = await meta.createSchema(payload)
+
+      ui.setNotification({
+        id: payload.name,
+        category: 'success',
+        message: `Schema ${schema.name} is good to go!`,
+      })
+
+    } catch (error: any) {
+      ui.setNotification({ id: payload.name, category: 'error', message: error.message })
+    }
+
+    closePanel()
+    resolve()
+  }
+
   const onClosePanel = () => {
     if (isEdited) {
       setIsClosingPanel(true)
@@ -257,6 +279,11 @@ const SidePanelEditor: FC<Props> = ({
         closePanel={onClosePanel}
         saveChanges={saveTable}
         updateEditorDirty={() => setIsEdited(true)}
+      />
+      <SchemaEditor
+        visible={sidePanelKey === 'schema'}
+        closePanel={onClosePanel}
+        saveChanges={saveSchema}
       />
       <ConfirmationModal
         visible={isClosingPanel}

--- a/studio/components/interfaces/TableGridEditor/SidePanelEditor/TableEditor/TableEditor.tsx
+++ b/studio/components/interfaces/TableGridEditor/SidePanelEditor/TableEditor/TableEditor.tsx
@@ -112,6 +112,7 @@ const TableEditor: FC<Props> = ({
       if (isEmpty(errors)) {
         const payload: CreateTablePayload | UpdateTablePayload = {
           name: tableFields.name,
+          schema: selectedSchema,
           comment: tableFields.comment,
           ...(!isNewRecord && { rls_enabled: tableFields.isRLSEnabled }),
         }

--- a/studio/components/interfaces/TableGridEditor/TableGridEditor.tsx
+++ b/studio/components/interfaces/TableGridEditor/TableGridEditor.tsx
@@ -20,7 +20,7 @@ interface Props {
   selectedTable: any // PostgresTable | SchemaView
 
   /** Determines what side panel editor to show */
-  sidePanelKey?: 'row' | 'column' | 'table'
+  sidePanelKey?: 'row' | 'column' | 'table' | 'schema'
   /** Toggles if we're duplicating a table */
   isDuplicating: boolean
   /** Selected entities if we're editting a row, column or table */
@@ -135,7 +135,7 @@ const TableGridEditor: FC<Props> = ({
         theme={theme}
         gridProps={{ height: '100%' }}
         storageRef={projectRef}
-        editable={!isViewSelected && selectedTable.schema === 'public'}
+        editable={!isViewSelected}
         schema={selectedTable.schema}
         table={gridTable}
         headerActions={

--- a/studio/components/layouts/TableEditorLayout/TableEditorLayout.tsx
+++ b/studio/components/layouts/TableEditorLayout/TableEditorLayout.tsx
@@ -12,6 +12,7 @@ interface Props {
   selectedSchema?: string
   onSelectSchema: (schema: string) => void
   onAddTable: () => void
+  onAddSchema: () => void
   onEditTable: (table: PostgresTable) => void
   onDeleteTable: (table: PostgresTable) => void
   onDuplicateTable: (table: PostgresTable) => void
@@ -21,6 +22,7 @@ interface Props {
 const TableEditorLayout: FC<Props> = ({
   selectedSchema,
   onSelectSchema = () => {},
+  onAddSchema = () => {},
   onAddTable = () => {},
   onEditTable = () => {},
   onDeleteTable = () => {},
@@ -66,6 +68,7 @@ const TableEditorLayout: FC<Props> = ({
           selectedSchema={selectedSchema}
           onSelectSchema={onSelectSchema}
           onAddTable={onAddTable}
+          onAddSchema={onAddSchema}
           onEditTable={onEditTable}
           onDeleteTable={onDeleteTable}
           onDuplicateTable={onDuplicateTable}

--- a/studio/components/layouts/TableEditorLayout/TableEditorMenu.tsx
+++ b/studio/components/layouts/TableEditorLayout/TableEditorMenu.tsx
@@ -29,6 +29,7 @@ interface Props {
   selectedSchema?: string
   onSelectSchema: (schema: string) => void
   onAddTable: () => void
+  onAddSchema: () => void
   onEditTable: (table: PostgresTable) => void
   onDeleteTable: (table: PostgresTable) => void
   onDuplicateTable: (table: PostgresTable) => void
@@ -38,6 +39,7 @@ const TableEditorMenu: FC<Props> = ({
   selectedSchema,
   onSelectSchema = () => {},
   onAddTable = () => {},
+  onAddSchema = () => {},
   onEditTable = () => {},
   onDeleteTable = () => {},
   onDuplicateTable = () => {},
@@ -129,25 +131,40 @@ const TableEditorMenu: FC<Props> = ({
       </div>
 
       <div className="space-y-1">
-        {selectedSchema === 'public' && (
-          <div className="px-3">
-            {/* Add new table button */}
-            <Button
-              block
-              size="tiny"
-              icon={
-                <div className="text-scale-900">
-                  <IconEdit size={14} strokeWidth={1.5} />
-                </div>
-              }
-              type="default"
-              style={{ justifyContent: 'start' }}
-              onClick={onAddTable}
-            >
-              New table
-            </Button>
-          </div>
-        )}
+        <div className="px-3">
+          {/* Add new schema button */}
+          <Button
+            block
+            size="tiny"
+            icon={
+              <div className="text-scale-900">
+                <IconEdit size={14} strokeWidth={1.5} />
+              </div>
+            }
+            type="default"
+            style={{ justifyContent: 'start' }}
+            onClick={onAddSchema}
+          >
+            New Schema
+          </Button>
+        </div>
+        <div className="px-3">
+          {/* Add new table button */}
+          <Button
+            block
+            size="tiny"
+            icon={
+              <div className="text-scale-900">
+                <IconEdit size={14} strokeWidth={1.5} />
+              </div>
+            }
+            type="default"
+            style={{ justifyContent: 'start' }}
+            onClick={onAddTable}
+          >
+            New table
+          </Button>
+        </div>
         {/* Table search input */}
         <div className="block mb-2 px-3">
           <Input

--- a/studio/pages/project/[ref]/auth/policies.tsx
+++ b/studio/pages/project/[ref]/auth/policies.tsx
@@ -73,7 +73,7 @@ const AuthPolicies = observer(() => {
   const PageState: any = useContext(PageContext)
 
   const { meta } = useStore()
-  const tables = meta.tables.list((table: any) => table.schema === 'public')
+  const tables = meta.tables.list((table: any) => table.schema)
 
   useEffect(() => {
     PageState.tablesLoading = false
@@ -157,7 +157,7 @@ const AuthPoliciesTables = observer(() => {
 
   const refreshTables = async () => {
     await meta.tables.load()
-    const res: any = meta.tables.list((table: any) => table.schema === 'public')
+    const res: any = meta.tables.list((table: any) => table.schema)
     if (!res.error) PageState.tables.replace(res)
   }
 

--- a/studio/pages/project/[ref]/editor/[id].tsx
+++ b/studio/pages/project/[ref]/editor/[id].tsx
@@ -26,7 +26,7 @@ const TableEditorPage: NextPage = () => {
   const [selectedColumnToDelete, setSelectedColumnToDelete] = useState<PostgresColumn>()
   const [selectedTableToDelete, setSelectedTableToDelete] = useState<PostgresTable>()
 
-  const [sidePanelKey, setSidePanelKey] = useState<'row' | 'column' | 'table'>()
+  const [sidePanelKey, setSidePanelKey] = useState<'row' | 'column' | 'table' | 'schema'>()
   const [selectedRowToEdit, setSelectedRowToEdit] = useState<Dictionary<any>>()
   const [selectedColumnToEdit, setSelectedColumnToEdit] = useState<PostgresColumn>()
   const [selectedTableToEdit, setSelectedTableToEdit] = useState<PostgresTable>()
@@ -70,6 +70,12 @@ const TableEditorPage: NextPage = () => {
 
   const onAddTable = () => {
     setSidePanelKey('table')
+    setIsDuplicating(false)
+    setSelectedTableToEdit(undefined)
+  }
+
+  const onAddSchema = () => {
+    setSidePanelKey('schema')
     setIsDuplicating(false)
     setSelectedTableToEdit(undefined)
   }
@@ -148,6 +154,7 @@ const TableEditorPage: NextPage = () => {
       selectedSchema={selectedSchema}
       onSelectSchema={setSelectedSchema}
       onAddTable={onAddTable}
+      onAddSchema={onAddSchema}
       onEditTable={onEditTable}
       onDeleteTable={onDeleteTable}
       onDuplicateTable={onDuplicateTable}

--- a/studio/pages/project/[ref]/editor/index.tsx
+++ b/studio/pages/project/[ref]/editor/index.tsx
@@ -14,15 +14,21 @@ import { SidePanel } from '@supabase/ui'
 const Editor: NextPage = () => {
   const { meta, ui } = useStore()
   const projectRef = ui.selectedProject?.ref
-  const [sidePanelKey, setSidePanelKey] = useState<'row' | 'column' | 'table'>()
+  const [sidePanelKey, setSidePanelKey] = useState<'row' | 'column' | 'table' | 'schema'>()
   const [isDeleting, setIsDeleting] = useState<boolean>(false)
   const [isDuplicating, setIsDuplicating] = useState<boolean>(false)
-  const [selectedSchema, setSelectedSchema] = useState<string>('public')
+  const [selectedSchema, setSelectedSchema] = useState<string>('auth')
   const [selectedTableToEdit, setSelectedTableToEdit] = useState<PostgresTable>()
   const [selectedTableToDelete, setSelectedTableToDelete] = useState<PostgresTable>()
 
   const onAddTable = () => {
     setSidePanelKey('table')
+    setIsDuplicating(false)
+    setSelectedTableToEdit(undefined)
+  }
+
+  const onAddSchema = () => {
+    setSidePanelKey('schema')
     setIsDuplicating(false)
     setSelectedTableToEdit(undefined)
   }
@@ -69,6 +75,7 @@ const Editor: NextPage = () => {
       selectedSchema={selectedSchema}
       onSelectSchema={setSelectedSchema}
       onAddTable={onAddTable}
+      onAddSchema={onAddSchema}
       onEditTable={onEditTable}
       onDeleteTable={onDeleteTable}
       onDuplicateTable={onDuplicateTable}

--- a/studio/stores/pgmeta/MetaStore.ts
+++ b/studio/stores/pgmeta/MetaStore.ts
@@ -97,6 +97,9 @@ export interface IMetaStore {
     columns: ColumnField[],
     importContent?: ImportContent
   ) => any
+  createSchema: (
+    payload: string
+  ) => any
   updateTable: (toastId: string, table: PostgresTable, payload: any, columns: ColumnField[]) => any
 }
 export default class MetaStore implements IMetaStore {
@@ -345,6 +348,16 @@ export default class MetaStore implements IMetaStore {
     }
 
     return duplicatedTable
+  }
+
+  async createSchema(
+    payload: any,
+  ) {
+    // Create the schema first
+    const schema: any = await this.schemas.create(payload)
+    if (schema.error) throw schema.error
+
+    return schema;
   }
 
   async createTable(


### PR DESCRIPTION
## What kind of change does this PR introduce?

Current PR allows for Supabase users to create new schemas. Also now users will be able to create/edit/duplicate tables, add new rows/columns inside **ALL** schemas

